### PR TITLE
Android sdk versions 5 & 6 video upload failure "Unfortunately, Camera has stopped"

### DIFF
--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -266,8 +266,9 @@ public class FsActivity extends AppCompatActivity implements
         menu.findItem(R.id.action_about).setVisible(showVersionInfo);
         for (int i = 0; i < menu.size(); i++) {
             MenuItem item = menu.getItem(i);
-            Drawable drawable = DrawableCompat.wrap(item.getIcon());
-            if (drawable != null) {
+            Drawable icon = item.getIcon();
+            Drawable drawable = DrawableCompat.wrap(icon);
+            if (icon != null && drawable != null) {
                 drawable.setColorFilter(theme.getBackgroundColor(), PorterDuff.Mode.SRC_ATOP);
                 DrawableCompat.setTint(drawable, theme.getBackgroundColor());
                 item.setIcon(drawable);

--- a/filestack/src/main/java/com/filestack/android/internal/Util.java
+++ b/filestack/src/main/java/com/filestack/android/internal/Util.java
@@ -3,6 +3,7 @@ package com.filestack.android.internal;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.support.v4.content.FileProvider;
 import android.support.v4.content.MimeTypeFilter;
@@ -188,8 +189,14 @@ public class Util {
     // If we don't do this, we'll get the exception when sending the URI to the camera app
     // See the FileProvider example in https://developer.android.com/training/camera/photobasics
     public static Uri getUriForInternalMedia(Context context, File file) {
-        String authority = context.getPackageName() + ".fileprovider";
-        return FileProvider.getUriForFile(context, authority, file);
+        Uri uri;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            String authority = context.getPackageName() + ".fileprovider";
+            uri =  FileProvider.getUriForFile(context, authority, file);
+        } else {
+            uri = Uri.fromFile(file);
+        }
+        return uri;
     }
 
     // TODO This doesn't seem to work


### PR DESCRIPTION
## Expected behavior
When taking video from camera intent started from filestack picker, upload happens normally

## Observed behavior
Video is taken normally. Afterwards, dialog appears -> "Unfortunately, Camera has stopped": no file is available for upload.
```
8-12 13:21:55.634 32446-32446/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.sec.android.app.camera, PID: 32446
    java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=2002, result=-1, data=Intent { act=inline-data dat=content://co.suitable.dev.fileprovider/movies/Android/data/co.suitable.dev/files/Movies/MP4_20190812_132136_1907016959.mp4 (has extras) }} to activity {com.sec.android.app.camera/com.sec.android.app.camera.Camcorder}: java.lang.IllegalStateException: Couldn't read row 0, col -1 from CursorWindow.  Make sure the Cursor is initialized correctly before accessing data from it.
        at android.app.ActivityThread.deliverResults(ActivityThread.java:4058)
        at android.app.ActivityThread.handleSendResult(ActivityThread.java:4101)
        at android.app.ActivityThread.access$1400(ActivityThread.java:177)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1497)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:145)
        at android.app.ActivityThread.main(ActivityThread.java:5942)
        at java.lang.reflect.Method.invoke(Native Method)
        at java.lang.reflect.Method.invoke(Method.java:372)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1399)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1194)
     Caused by: java.lang.IllegalStateException: Couldn't read row 0, col -1 from CursorWindow.  Make sure the Cursor is initialized correctly before accessing data from it.
        at android.database.CursorWindow.nativeGetLong(Native Method)
        at android.database.CursorWindow.getLong(CursorWindow.java:524)
        at android.database.AbstractWindowedCursor.getLong(AbstractWindowedCursor.java:75)
        at android.database.CursorWrapper.getLong(CursorWrapper.java:106)
        at com.sec.android.app.camera.Camera.onActivityResult(Camera.java:6197)
        at android.app.Activity.dispatchActivityResult(Activity.java:6549)
        at android.app.ActivityThread.deliverResults(ActivityThread.java:4054)
        at android.app.ActivityThread.handleSendResult(ActivityThread.java:4101) 
        at android.app.ActivityThread.access$1400(ActivityThread.java:177) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1497) 
        at android.os.Handler.dispatchMessage(Handler.java:102) 
        at android.os.Looper.loop(Looper.java:145) 
        at android.app.ActivityThread.main(ActivityThread.java:5942) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at java.lang.reflect.Method.invoke(Method.java:372) 
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1399) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1194) 
```

## Fix
- Change the way file uri is generated for sdk < 7
- See more information [here](https://www.e-learn.cn/content/wangluowenzhang/2205560)